### PR TITLE
Prevent cito from crashing when parsing symbols instead of types in method parameters.

### DIFF
--- a/CiResolver.cs
+++ b/CiResolver.cs
@@ -1394,6 +1394,10 @@ public class CiResolver : CiVisitor
 				ExpectNoPtrModifier(expr, ptrModifier);
 				return type;
 			}
+			
+			if (symbol.Name == null && symbol.Symbol != null)
+				throw StatementException(expr, "Type {0} is not available here", symbol.Symbol.Name);
+			
 			throw StatementException(expr, "Type {0} not found", symbol.Name);
 
 		case CiCallExpr call:

--- a/CiTree.cs
+++ b/CiTree.cs
@@ -202,6 +202,9 @@ public abstract class CiScope : CiSymbol, IEnumerable<CiSymbol>
 
 	public virtual CiSymbol TryLookup(string name)
 	{
+		if (name == null)
+			return null;
+
 		for (CiScope scope = this; scope != null; scope = scope.Parent) {
 			object result = scope.Dict[name];
 			if (result != null)


### PR DESCRIPTION
If I have the following method:
```csharp
public void doSomething(List<int> values) {}
```

I get this crash:
```
Unhandled exception. System.ArgumentNullException: Key cannot be null. (Parameter 'key')
   at System.Collections.Hashtable.get_Item(Object key)
   at System.Collections.Specialized.OrderedDictionary.get_Item(Object key)
   at Foxoft.Ci.CiScope.TryLookup(String name) in C:\Users\marco\source\repos\cito\CiTree.cs:line 206
   at Foxoft.Ci.CiResolver.ToBaseType(CiExpr expr, CiToken ptrModifier) in C:\Users\marco\source\repos\cito\CiResolver.cs:line 1385
   at Foxoft.Ci.CiResolver.ToType(CiExpr expr, Boolean dynamic) in C:\Users\marco\source\repos\cito\CiResolver.cs:line 1498
   at Foxoft.Ci.CiResolver.ResolveType(CiNamedValue def) in C:\Users\marco\source\repos\cito\CiResolver.cs:line 1508
   at Foxoft.Ci.CiResolver.ResolveTypes(CiClass klass) in C:\Users\marco\source\repos\cito\CiResolver.cs:line 1590
   at Foxoft.Ci.CiResolver..ctor(CiProgram program, IEnumerable`1 searchDirs, String lang) in C:\Users\marco\source\repos\cito\CiResolver.cs:line 1650
   at Foxoft.Ci.CiTo.ParseAndResolve(CiParser parser, CiScope parent, List`1 files, List`1 searchDirs, String lang) in C:\Users\marco\source\repos\cito\CiTo.cs:line 61
   at Foxoft.Ci.CiTo.Main(String[] args) in C:\Users\marco\source\repos\cito\CiTo.cs:line 148
```

Now it shows this:
```
ERROR: Type List is not available here
```


But I think that we should be able to pass Lists, Dictionaries, etc. to methods to.