### PR TITLE
Added binary and octal literals.

### DIFF
--- a/test/LexLiteralBin.ci
+++ b/test/LexLiteralBin.ci
@@ -1,0 +1,7 @@
+public static class Test
+{
+	public static bool Run()
+	{
+		return 0b00101011010 == 346;
+	}
+}

--- a/test/LexLiteralOctal.ci
+++ b/test/LexLiteralOctal.ci
@@ -1,0 +1,7 @@
+public static class Test
+{
+	public static bool Run()
+	{
+		return 0o370132 == 127066;
+	}
+}


### PR DESCRIPTION
Binary literals are really useful, specially when working with bit masks, I think they don't affect any other part of the language. As for the octals, somebody may use it...

```csharp
int a = 0b00101011010; // 346
int b = 0B00101011010; // 346
```
```csharp
int a = 0o370132; // 127066
int b = 0O370132; // 127066
```