### PR TITLE
ifstream.open does not take string_view

### DIFF
--- a/cito.cpp
+++ b/cito.cpp
@@ -76,7 +76,7 @@ class FileResourceSema : public CiSema
 				return;
 			}
 		}
-		stream.open(name, std::ios_base::binary);
+		stream.open(std::string{name}, std::ios_base::binary);
 		if (stream) {
 			std::string input = slurp(stream);
 			content.assign(input.begin(), input.end());
@@ -110,7 +110,7 @@ public:
 	std::ostream *createFile(std::string_view directory, std::string_view filename) override
 	{
 		if (directory.empty())
-			stream.open(filename, std::ios_base::binary);
+			stream.open(std::string{filename}, std::ios_base::binary);
 		else
 			stream.open(std::filesystem::path(directory) / filename, std::ios_base::binary);
 		return &stream;


### PR DESCRIPTION
Current code leads to 
```
cito.cpp: In member function 'virtual std::ostream* FileGenHost::createFile(std::string_view, std::string_view)':
cito.cpp:114:36: error: no matching function for call to 'std::basic_ofstream<char>::open(std::string_view&, const std::ios_base::openmode&)'
  114 |                         stream.open(filename, std::ios_base::binary);
      |                         ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from cito.cpp:23:
/usr/local/Cellar/gcc/13.1.0/include/c++/13/fstream:988:9: note: candidate: 'template<class _Path> std::_If_fs_path<_Path, void> std::basic_ofstream<_CharT, _Traits>::open(const _Path&, std::ios_base::openmode) [with _CharT = char; _Traits = std::char_traits<char>]'
  988 |         open(const _Path& __s, ios_base::openmode __mode = ios_base::out)
      |         ^~~~
/usr/local/Cellar/gcc/13.1.0/include/c++/13/fstream:988:9: note:   template argument deduction/substitution failed:
/usr/local/Cellar/gcc/13.1.0/include/c++/13/fstream: In substitution of 'template<class _Path> std::_If_fs_path<_Path, void, decltype (declval<_Path&>().make_preferred().filename())> std::basic_ofstream<char>::open(const _Path&, std::ios_base::openmode)[with _Path = std::basic_string_view<char>]':
cito.cpp:114:15:   required from here
/usr/local/Cellar/gcc/13.1.0/include/c++/13/fstream:988:9: error: 'class std::basic_string_view<char>' has no member named 'make_preferred'
/usr/local/Cellar/gcc/13.1.0/include/c++/13/fstream:928:7: note: candidate: 'void std::basic_ofstream<_CharT, _Traits>::open(const char*, std::ios_base::openmode) [with _CharT = char; _Traits = std::char_traits<char>; std::ios_base::openmode = std::ios_base::openmode]'
  928 |       open(const char* __s, ios_base::openmode __mode = ios_base::out)
      |       ^~~~
/usr/local/Cellar/gcc/13.1.0/include/c++/13/fstream:928:24: note:   no known conversion for argument 1 from 'std::string_view' {aka 'std::basic_string_view<char>'} to 'const char*'
  928 |       open(const char* __s, ios_base::openmode __mode = ios_base::out)
      |            ~~~~~~~~~~~~^~~
/usr/local/Cellar/gcc/13.1.0/include/c++/13/fstream:967:7: note: candidate: 'void std::basic_ofstream<_CharT, _Traits>::open(const std::string&, std::ios_base::openmode) [with _CharT = char; _Traits = std::char_traits<char>; std::string = std::__cxx11::basic_string<char>; std::ios_base::openmode = std::ios_base::openmode]'
  967 |       open(const std::string& __s, ios_base::openmode __mode = ios_base::out)
      |       ^~~~
/usr/local/Cellar/gcc/13.1.0/include/c++/13/fstream:967:31: note:   no known conversion for argument 1 from 'std::string_view' {aka 'std::basic_string_view<char>'} to 'const std::string&' {aka 'const std::__cxx11::basic_string<char>&'}
  967 |       open(const std::string& __s, ios_base::openmode __mode = ios_base::out)
      |            ~~~~~~~~~~~~~~~~~~~^~~

```
Am I missing something?