### PR TITLE
Add CMake modules for finding and and executing Fusion

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -7,14 +7,18 @@ option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 find_package(Fusion 3.2 REQUIRED)
 include(${FUSION_USE_FILE})
 
-# Create the library.
+# Create the C++ library.
 fusion_transpile(
   SOURCES fibonacci.fu
   OUTPUT ${CMAKE_BINARY_DIR}/fibonacci.cpp
 )
 add_library(fibonacci fibonacci.cpp)
+set_target_properties(fibonacci
+  PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_BINARY_DIR}"
+)
 
-# Create tests.
+# Create C++ tests.
 fusion_transpile(
   SOURCES tests.fu
   OUTPUT ${CMAKE_BINARY_DIR}/tests.cpp
@@ -26,3 +30,46 @@ target_link_libraries(tests fibonacci)
 # Add test target.
 include(CTest)
 add_test(NAME tests COMMAND tests)
+
+# (Optional) Create bindings via SWIG.
+cmake_policy(SET CMP0086 NEW)
+find_package(SWIG 4.0)
+if(SWIG_FOUND)
+  include(${SWIG_USE_FILE})
+
+  find_package(Lua)
+  if(Lua_FOUND)
+    # See: https://cmake.org/cmake/help/latest/module/FindLua.html
+    if (NOT TARGET Lua::Lua)
+      add_library(Lua::Lua INTERFACE IMPORTED)
+      set_target_properties(Lua::Lua
+        PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${LUA_INCLUDE_DIR}"
+        INTERFACE_LINK_LIBRARIES "${LUA_LIBRARIES}"
+      )
+    endif()
+
+    set_source_files_properties(fibonacci.i
+      PROPERTIES
+      # Call SWIG in C++ mode.
+      CPLUSPLUS ON
+      # Specify the actual import name of the module in the target language.
+      SWIG_MODULE_NAME fibonacci_lua
+    )
+
+    # Generate, compile, and link the Lua binding.
+    swig_add_library(fibonacci_lua
+      SOURCES fibonacci.i
+      TYPE SHARED
+      LANGUAGE lua)
+    target_link_libraries(fibonacci_lua
+      PRIVATE fibonacci Lua::Lua
+    )
+
+    set_target_properties(fibonacci_lua
+      PROPERTIES
+      # Align library name with `SWIG_MODULE_NAME` for seamless Lua import.
+      PREFIX ""
+    )
+  endif()
+endif()

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.13)
+project(Fibonacci VERSION 1.0.0 LANGUAGES CXX)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR})
+option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+
+# Find the Fusion transpiler.
+find_package(Fusion 3.2 REQUIRED)
+include(${FUSION_USE_FILE})
+
+# Create the library.
+fusion_transpile(
+  SOURCES fibonacci.fu
+  OUTPUT ${CMAKE_BINARY_DIR}/fibonacci.cpp
+)
+add_library(fibonacci fibonacci.cpp)
+
+# Create tests.
+fusion_transpile(
+  SOURCES tests.fu
+  OUTPUT ${CMAKE_BINARY_DIR}/tests.cpp
+  REFERENCE fibonacci.fu
+)
+add_executable(tests tests.cpp)
+target_link_libraries(tests fibonacci)
+
+# Add test target.
+include(CTest)
+add_test(NAME tests COMMAND tests)

--- a/cmake/FindFusion.cmake
+++ b/cmake/FindFusion.cmake
@@ -1,0 +1,71 @@
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+#[=======================================================================[.rst:
+FindFusion
+----------
+
+Find the Fusion transpiler (fut) executable.
+
+This module finds an installed Fusion transpiler and determines its
+version. The following variables are defined:
+
+``Fusion_FOUND``
+  Whether Fusion was found on the system.
+``FUSION_EXECUTABLE``
+  Path to the fut executable.
+``FUSION_VERSION``
+  Fusion executable version (result of ``fut --version``).
+``FUSION_USE_FILE``
+  Path to UseFusion.cmake for convenience macros.
+
+All information is collected from the ``FUSION_EXECUTABLE``, so the
+version to be found can be changed from the command line by means of
+setting ``FUSION_EXECUTABLE``.
+
+Example usage:
+
+.. code-block:: cmake
+
+   find_package(Fusion 3.0 REQUIRED)
+   include(${FUSION_USE_FILE})
+
+#]=======================================================================]
+
+find_program(FUSION_EXECUTABLE
+  NAMES fut
+  DOC "Path to Fusion transpiler"
+)
+
+if(FUSION_EXECUTABLE)
+  execute_process(
+    COMMAND "${FUSION_EXECUTABLE}" --version
+    OUTPUT_VARIABLE FUSION_VERSION_OUTPUT
+    ERROR_VARIABLE FUSION_VERSION_OUTPUT
+    RESULT_VARIABLE FUSION_VERSION_RESULT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+
+  if(FUSION_VERSION_RESULT EQUAL 0)
+    string(REGEX MATCH "[0-9]+\\.[0-9]+(\\.[0-9]+)?"
+      FUSION_VERSION "${FUSION_VERSION_OUTPUT}")
+  endif()
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Fusion
+  REQUIRED_VARS FUSION_EXECUTABLE
+  VERSION_VAR FUSION_VERSION
+)
+
+if(Fusion_FOUND)
+  set(FUSION_USE_FILE "${CMAKE_CURRENT_LIST_DIR}/UseFusion.cmake")
+
+  if(NOT TARGET Fusion::fut)
+    add_executable(Fusion::fut IMPORTED)
+    set_target_properties(Fusion::fut PROPERTIES
+      IMPORTED_LOCATION "${FUSION_EXECUTABLE}"
+    )
+  endif()
+endif()
+
+mark_as_advanced(FUSION_EXECUTABLE FUSION_VERSION)

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -1,0 +1,11 @@
+This directory contains CMake modules for finding and executing
+[Fusion](https://fusion-lang.org) in CMake projects. The provided
+example project (cf. [CMakeLists.txt](CMakeLists.txt)) can be built as
+follows:
+
+```sh
+mkdir build && cd build
+cmake ..
+cmake --build .
+cmake --build . --target test
+```

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -9,3 +9,20 @@ cmake ..
 cmake --build .
 cmake --build . --target test
 ```
+
+This builds a C++ library for computing Fibonacci numbers as well as a
+test binary, which is executed in the `test` target. Furthermore, if
+[SWIG](https://www.swig.org) and [Lua](https://www.lua.org) are
+installed, Lua bindings for the Fusion-transpiled C++ library are
+automatically generated. The binding can be loaded as follows:
+
+```lua
+require("fibonacci_lua")
+fibonacci_lua.Fibonacci_fib(20)
+```
+
+Note: Static class members present a special problem for Lua. Hence,
+SWIG generates wrappers that try to work around some of these issues
+(cf. https://www.swig.org/Doc4.0/Lua.html#Lua_nn14). Specifically, the
+static member function `fib` of class `Fibonacci` is wrapped as a
+global function with name `Fibonacci_fib`.

--- a/cmake/UseFusion.cmake
+++ b/cmake/UseFusion.cmake
@@ -1,0 +1,123 @@
+# Distributed under the OSI-approved BSD 3-Clause License.
+
+#[=======================================================================[.rst:
+UseFusion
+---------
+
+This file provides support for ``Fusion``. It is assumed that the
+:module:`FindFusion` module has already been loaded. For example:
+
+.. code-block:: cmake
+
+   find_package(Fusion REQUIRED)
+   include(${FUSION_USE_FILE})
+
+CMake Commands
+^^^^^^^^^^^^^^
+
+The following command is defined for use with ``Fusion``:
+
+.. command:: fusion_transpile
+
+  Transpile the given source file(s).
+
+  .. code-block:: cmake
+
+     fusion_transpile(
+       SOURCES <file1.fu> <file2.fu> ...
+       OUTPUT <output>
+       [NAMESPACE <namespace>]
+       [DEFINES <symbol1> <symbol2> ...]
+       [REFERENCE <file1.fu> <file2.fu> ...]
+       [INCLUDE_DIRS <dir1> <dir2> ...]
+     )
+
+  ``SOURCES``
+    The input source file(s) to transpile (required).
+  ``OUTPUT``
+    The output path for the transpiled code (required). The target
+    language is derived from the name suffix. For example, hello.c
+    emits C code. The following suffixes (targets) are supported:
+    c (C), cpp (C++), cs (C#), d (D), java (Java), js (JavaScript),
+    py (Python), swift (Swift), ts (TypeScript), d.ts (TypeScript
+    declarations), cl (OpenCL C).
+  ``NAMESPACE``
+    Specify C++/C# namespace, Java package, or C name prefix.
+  ``DEFINES``
+    List of conditional compilation symbols.
+  ``REFERENCE``
+    List of additional source files to read but not emit code for.
+  ``INCLUDE_DIRS``
+    List of directories to add to resource search path.
+
+  Example usage:
+
+  .. code-block:: cmake
+
+     fusion_transpile(
+       SOURCES hello.fu
+       OUTPUT ${CMAKE_BINARY_DIR}/hello.cpp
+     )
+
+     add_library(hello hello.cpp)
+
+     fusion_transpile(
+       SOURCES tests.fu
+       OUTPUT ${CMAKE_BINARY_DIR}/tests.cpp
+       REFERENCE hello.fu
+     )
+
+     add_executable(tests tests.cpp)
+     target_link_libraries(tests hello)
+
+#]=======================================================================]
+
+function(fusion_transpile)
+  if(NOT Fusion_FOUND)
+    message(FATAL_ERROR "Fusion not found")
+  endif()
+
+  set(options "")
+  set(oneValueArgs OUTPUT NAMESPACE)
+  set(multiValueArgs DEFINES REFERENCE INCLUDE_DIRS SOURCES)
+  cmake_parse_arguments(FUSION
+    "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN}
+  )
+
+  if(NOT FUSION_SOURCES)
+    message(FATAL_ERROR "SOURCES is required")
+  endif()
+  if(NOT FUSION_OUTPUT)
+    message(FATAL_ERROR "OUTPUT is required")
+  endif()
+
+  set(FUSION_ARGS -o ${FUSION_OUTPUT})
+  if(FUSION_NAMESPACE)
+    list(APPEND FUSION_ARGS -n ${FUSION_NAMESPACE})
+  endif()
+  foreach(def ${FUSION_DEFINES})
+    list(APPEND FUSION_ARGS -D ${def})
+  endforeach()
+  foreach(res ${FUSION_REFERENCE})
+    list(APPEND FUSION_ARGS -r ${res})
+  endforeach()
+  foreach(inc ${FUSION_INCLUDE_DIRS})
+    list(APPEND FUSION_ARGS -I ${inc})
+  endforeach()
+  foreach(src ${FUSION_SOURCES})
+    list(APPEND FUSION_ARGS ${src})
+  endforeach()
+
+  # Create output directory structure.
+  get_filename_component(OUTPUT_DIR ${FUSION_OUTPUT} DIRECTORY)
+  file(MAKE_DIRECTORY ${OUTPUT_DIR})
+
+  add_custom_command(
+    OUTPUT ${FUSION_OUTPUT}
+    COMMAND ${FUSION_EXECUTABLE} ${FUSION_ARGS}
+    DEPENDS ${FUSION_SOURCES} ${FUSION_REFERENCE}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMENT "Transpiling ${FUSION_SOURCES} to ${FUSION_OUTPUT}"
+    VERBATIM
+  )
+endfunction()

--- a/cmake/fibonacci.fu
+++ b/cmake/fibonacci.fu
@@ -1,0 +1,15 @@
+public class Fibonacci
+{
+	public static int Fib(int n)
+	{
+		if (n == 0) return 0;
+		int prev = 1;
+		int curr = 1;
+		for (int i = 2; i < n; i++) {
+			int fib = prev + curr;
+			prev = curr;
+			curr = fib;
+		}
+		return curr;
+	}
+}

--- a/cmake/fibonacci.i
+++ b/cmake/fibonacci.i
@@ -1,0 +1,4 @@
+%{
+#include "fibonacci.hpp"
+%}
+%include "fibonacci.hpp"

--- a/cmake/tests.fu
+++ b/cmake/tests.fu
@@ -1,0 +1,18 @@
+native {
+#include "fibonacci.hpp"
+}
+
+public class Tests
+{
+	public static void Main()
+	{
+		assert Fibonacci.Fib(0) == 0;
+		assert Fibonacci.Fib(1) == 1;
+		assert Fibonacci.Fib(2) == 1;
+		assert Fibonacci.Fib(3) == 2;
+		assert Fibonacci.Fib(4) == 3;
+		assert Fibonacci.Fib(5) == 5;
+		assert Fibonacci.Fib(6) == 8;
+		assert Fibonacci.Fib(20) == 6765;
+	}
+}


### PR DESCRIPTION
Note that the CMake modules are licensed under the same terms as those modules shipped with CMake (the BSD 3-Clause License). I know that Fusion is licensed under the terms of the GPLv3 license, but I'm not sure what the implications are if these modules are included in other projects.